### PR TITLE
feat: type inventory scan summary

### DIFF
--- a/frontend/app/repos/[owner]/[repo]/page.tsx
+++ b/frontend/app/repos/[owner]/[repo]/page.tsx
@@ -1,5 +1,5 @@
 
-import { getInventory } from '@/lib/api'
+import { getInventory, type ScanSummary } from '@/lib/api'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 
 export default async function RepoPage({ params }: { params: { owner: string; repo: string } }) {
@@ -7,8 +7,8 @@ export default async function RepoPage({ params }: { params: { owner: string; re
   if (!data) {
     return <div className="card p-5">No scans yet for {params.owner}/{params.repo}</div>
   }
-  const { scan } = data
-  const s = scan.summary || {}
+  const scan: ScanSummary = data.scan
+  const s = scan.summary
   return (
     <main className="space-y-6">
       <Card>

--- a/frontend/components/InventorySummary.tsx
+++ b/frontend/components/InventorySummary.tsx
@@ -4,10 +4,11 @@ import { useEffect, useState } from 'react'
 import { Badge } from './ui/badge'
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 import Link from 'next/link'
+import type { ScanSummary } from '@/lib/api'
 
 type Props = { owner: string; repo: string }
 export function InventorySummary({ owner, repo }: Props) {
-  const [data, setData] = useState<any | null>(null)
+  const [scan, setScan] = useState<ScanSummary | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -17,21 +18,20 @@ export function InventorySummary({ owner, repo }: Props) {
       .then(({ ok, j }) => {
         if (!mounted) return
         if (!ok) setError(j.error || 'Failed to load')
-        else setData(j)
+        else setScan(j.scan)
       })
       .catch(e => mounted && setError(String(e)))
     return () => { mounted = false }
   }, [owner, repo])
 
   if (error) return <div className="card p-5">Error: {error}</div>
-  if (!data) return <div className="card p-5">Loading…</div>
+  if (!scan) return <div className="card p-5">Loading…</div>
 
-  const s = data.scan
-  const summary = s?.summary || {}
+  const summary = scan.summary
   const chart = [
-    { name: 'files', value: summary.files || 0 },
-    { name: 'dependencies', value: summary.dependencies || 0 },
-    { name: 'vulnerabilities', value: summary.vulns || 0 }
+    { name: 'files', value: summary.files ?? 0 },
+    { name: 'dependencies', value: summary.dependencies ?? 0 },
+    { name: 'vulnerabilities', value: summary.vulns ?? 0 }
   ]
 
   return (
@@ -39,7 +39,7 @@ export function InventorySummary({ owner, repo }: Props) {
       <div className="flex items-center justify-between mb-4">
         <div>
           <h3 className="text-lg font-semibold">{owner}/{repo}</h3>
-          <p className="text-sm text-neutral-600">Scan #{s.id} • Status: <Badge>{s.status}</Badge></p>
+          <p className="text-sm text-neutral-600">Scan #{scan.id} • Status: <Badge>{scan.status}</Badge></p>
         </div>
         <Link href={`/repos/${owner}/${repo}`} className="btn">Open details</Link>
       </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -16,9 +16,23 @@ export async function enqueueScan(input: { owner: string; repo: string; gitRef?:
   return res.json() as Promise<{ scanId: number | string }>
 }
 
+export interface ScanSummary {
+  id: number
+  status: string
+  summary: {
+    files: number
+    dependencies: number
+    vulns: number
+    issues?: number
+    prs?: number
+  }
+  started_at: string
+  finished_at?: string
+}
+
 export async function getInventory(owner: string, repo: string) {
   const res = await fetch(`${BACKEND_URL}/v1/repos/${owner}/${repo}/inventory`, { cache: 'no-store' })
   if (res.status === 404) return null
   if (!res.ok) throw new Error(`inventory error ${res.status}`)
-  return res.json() as Promise<{ scan: { id: number; status: string; summary: any; started_at: string; finished_at?: string } }>
+  return res.json() as Promise<{ scan: ScanSummary }>
 }


### PR DESCRIPTION
## Summary
- add `ScanSummary` interface to describe inventory scans and return typed result from `getInventory`
- refactor `InventorySummary` component to use typed `ScanSummary` state
- update repo page to consume new interface

## Testing
- `npm test` (fails: Invalid configuration - Required env vars)
- `npm run lint` (fails: Unexpected any and other lint errors)
- `npm run lint:frontend` (fails: Invalid options for next lint)


------
https://chatgpt.com/codex/tasks/task_e_68b3c366650883209eaf1dfdef109011