### PR TITLE
Require backend URL env var for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ CORS_ORIGIN=http://localhost:3001
 
 ```env
 # API Configuration
-NEXT_PUBLIC_API_URL=http://localhost:3000
+NEXT_PUBLIC_BACKEND_URL=http://localhost:3000
 NEXT_PUBLIC_GITHUB_CLIENT_ID=your_github_client_id
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     environment:
-      NEXT_PUBLIC_API_URL: http://localhost:3000
+      NEXT_PUBLIC_BACKEND_URL: http://localhost:3000
       NEXT_PUBLIC_GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
     ports:
       - "3001:3001"

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,4 @@
+# Environment variables for the frontend
+NEXT_PUBLIC_BACKEND_URL=http://localhost:3000
+# NEXT_PUBLIC_GITHUB_CLIENT_ID=your_github_client_id
+

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,5 +1,7 @@
 
-export const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3000'
+const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
+if (!backendUrl) throw new Error('NEXT_PUBLIC_BACKEND_URL is not defined')
+export const BACKEND_URL = backendUrl
 
 // Server-side proxy helpers
 export async function enqueueScan(input: { owner: string; repo: string; gitRef?: string; jwt: string }) {


### PR DESCRIPTION
## Summary
- remove hardcoded backend URL fallback and error when `NEXT_PUBLIC_BACKEND_URL` is missing
- document `NEXT_PUBLIC_BACKEND_URL` in frontend env example and README
- ensure deployment uses `NEXT_PUBLIC_BACKEND_URL` instead of `NEXT_PUBLIC_API_URL`

## Testing
- `npm test` *(fails: invalid configuration)*
- `npm run test:frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c368ff5483209e3e16b50bec94a1